### PR TITLE
Add testnet instructions and Dockerfile

### DIFF
--- a/Dockerfile.testnet
+++ b/Dockerfile.testnet
@@ -49,14 +49,6 @@ COPY . ./parachain
 RUN cd parachain \
 	&& cargo b -rp tangle-cli --features with-tangle-kusama-runtime
 
-# Expose node ports.
-EXPOSE 43677
-EXPOSE 33443
-
-# Expose Prometheus ports for metrics.
-EXPOSE 44107
-EXPOSE 43831
-
 # Set the working directory to the parachain directory.
 WORKDIR /app/parachain
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ You can get started quickly by using the provided `Dockerfile.testnet` file to l
 
 ```bash
 docker build -f Dockerfile.testnet -t tangle-restaking-parachain .
-docker run -it tangle-restaking-parachain
+
+# Run the Docker container with the ports published to the host.
+docker run -it \
+  -p 30334:30334 -p 9933:9933 -p 9615:9615 \
+  -p 30335:30335 -p 9934:9934 -p 9616:9616 \
+  -p 30336:30336 -p 9935:9935 -p 9617:9617 \
+  -p 30337:30337 -p 9936:9936 -p 9618:9618 \
+  tangle-restaking-parachain
 ```
 
 Alternatively, follow the instructions below to install `zombienet` and `polkadot` binaries on your local machine.

--- a/scripts/zombienet.toml
+++ b/scripts/zombienet.toml
@@ -5,13 +5,19 @@ timeout = 1000
 default_command = "polkadot"
 chain = "rococo-local"
 
-    [[relaychain.nodes]]
-    name = "Alice"
-    validator = true
+[[relaychain.nodes]]
+name = "Alice"
+validator = true
+ws_port = 30334
+rpc_port = 9933
+prometheus_port = 9615
 
-    [[relaychain.nodes]]
-    name = "Bob"
-    validator = true
+[[relaychain.nodes]]
+name = "Bob"
+validator = true
+ws_port = 30335
+rpc_port = 9934
+prometheus_port = 9616
 
 [[parachains]]
 id = 1000
@@ -21,12 +27,18 @@ cumulus_based = true
 add_to_genesis = true
 register_para = true
 
-    [[parachains.collators]]
-    name = "Alice"
-    command = "./target/release/tangle"
-    collator = true
+[[parachains.collators]]
+name = "Alice"
+command = "./target/release/tangle"
+collator = true
+ws_port = 30336
+rpc_port = 9935
+prometheus_port = 9617
 
-    [[parachains.collators]]
-    name = "Bob"
-    command = "./target/release/tangle"
-    collator = true
+[[parachains.collators]]
+name = "Bob"
+command = "./target/release/tangle"
+collator = true
+ws_port = 30337
+rpc_port = 9936
+prometheus_port = 9618


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added clear instructions for setting up a testnet.
- Created a Dockerfile for convenience and as a 0 setup method, to save time. This will be especially useful for the Webb dapp team.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
